### PR TITLE
#162122903 fix liking and disliking functionality

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -53,6 +53,21 @@ class ArticlesSerializers(serializers.ModelSerializer):
         except:
             return False
 
+    like_status = serializers.SerializerMethodField()
+
+    def get_like_status(self, obj):
+        try:
+            like_dislike_entry = LikesDislikes.objects.values_list(
+                'likes',flat=True).filter(
+                reader=self.context["request"].user.id,article=obj.id
+                )
+            if (like_dislike_entry[0]):
+                return 'liked'
+            else:
+                return 'disliked'
+        except Exception as e:
+            return None
+
     tags = TagsRelation(many=True, required=False)
 
     author = serializers.SerializerMethodField(read_only=True)
@@ -150,7 +165,8 @@ class ArticlesSerializers(serializers.ModelSerializer):
             'dislikes_count',
             'created_at',
             'updated_at',
-            'favourited'
+            'favourited',
+            'like_status',
         )
 
     def create(self, validated_data):

--- a/authors/apps/articles/tests/test_likes.py
+++ b/authors/apps/articles/tests/test_likes.py
@@ -187,6 +187,25 @@ class LikesDislikesTests(BaseTest):
         old_count = 1
         self.client.delete(self.like_url, format='json')
         self.assertNotEqual(likes_count, old_count)
+    
+    def test_like_status_on_like(self):
+        """
+        Test that the like status is updated
+        """
+        response = self.client.get(self.article_url, format='json')
+        like_status = response.data['like_status']
+        self.create_like()
+        response = self.client.get(self.article_url, format='json')
+        new_like_status = response.data['like_status']
+        self.assertNotEqual(like_status, new_like_status)
+
+    def test_like_status_on_dislike(self):
+        response = self.client.get(self.article_url, format='json')
+        like_status = response.data['like_status']
+        self.create_dislike()
+        response = self.client.get(self.article_url, format='json')
+        new_like_status = response.data['like_status']
+        self.assertNotEqual(like_status, new_like_status)
 
     def test_delete_like_unauthenticated_user(self):
         """


### PR DESCRIPTION
#### What does this PR do?
- Have a fix for the liking and disliking functionality
#### Description of Task to be completed?
- Included a field in the article to show whether a user has liked, disliked or has not reacted to an article.

#### How should this be manually tested?
- Clone [this](https://github.com/andela/ah-shakas.git) repository and cd into the folder.
- Run the command ```git checkout ft-liking-unliking-articles-160577483```
- Create a ```.env``` file with the following values
```
DB_NAME=
DB_HOST=
DB_PASSWORD=
DB_USER=
EMAIL_HOST=smtp.sendgrid.net
EMAIL_HOST_USER=
EMAIL_HOST_PASSWORD=
EMAIL_PORT=
```
- Install the project dependencies by running ```pipenv install```
- Then to run the tests ren the command ```python manage.py test```
- Using [Postman](https://www.getpostman.com/) test every endpoint above after running the command ```python manage.py runserver```
- Create a user account by accessing ```POST api/users/``` and sending the following payload ```{ "user":{ "username":"username", "email":"username@gmail.com", "password": "password1234"}}```
- Confirm signup from the email sent to the address posted in the payload.
- Then login to get token to perform manual tests
_key_: Content-Type value: application/json
_key_: Authorization value: JWT Token generated either on signup or login
- Create an article by accessing ```POST api/articles/``` and pass in the following payload ```{"article":{"title":"title", "Title", "body": "My article"}}```
- get an article using the `api/article/:slug` endpoint and look out for the liked_status field
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#162122903](https://www.pivotaltracker.com/n/projects/2198533/stories/162122903)
#### Screenshots (if appropriate)
#### Questions: