### PR TITLE
fix (comments) add user profile to comments response

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -251,6 +251,8 @@ class CommentsSerializers(serializers.ModelSerializer):
 
     history = serializers.SerializerMethodField()
 
+    author = serializers.SerializerMethodField(read_only=True)
+
     def get_history(self, obj):
        return [
             {
@@ -258,6 +260,12 @@ class CommentsSerializers(serializers.ModelSerializer):
                 'created_at': self.format_date(history.created_at),
             }  for history in obj.history.all()
         ]
+
+    def get_author(self, obj):
+        """This method gets the profile object for the article"""
+        serializer = ProfileSerializer(
+            instance=Profile.objects.get(user=obj.author))
+        return serializer.data
 
     def format_date(self, date):
         return date.strftime('%d %b %Y %H:%M:%S')
@@ -271,7 +279,8 @@ class CommentsSerializers(serializers.ModelSerializer):
 
                     'id': thread.id,
                         'body': thread.body,
-                        'author': thread.author.username,
+                        'author': ProfileSerializer(
+                                instance=Profile.objects.get(user=thread.author)).data,
                         'created_at': self.format_date(thread.created_at),
                         'replies': thread.threads.count(),
                         'comment_like_count':thread.comment_likes.count(),
@@ -283,7 +292,6 @@ class CommentsSerializers(serializers.ModelSerializer):
        representation['created_at'] = self.format_date(instance.created_at)
        representation['updated_at'] = self.format_date(instance.updated_at)
        representation['comment_like_count']=instance.comment_likes.count()
-       representation['author'] = instance.author.username
        representation['article'] = instance.article.title
        representation['reply_count'] = instance.threads.count() 
        representation['threads'] = threads

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -328,7 +328,7 @@ class CommentsListCreateView(ListCreateAPIView):
         comment['article'] = article.pk
         serializer = self.serializer_class(data=comment)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        serializer.save(author=request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @receiver(post_save, sender=Comment)
@@ -427,14 +427,13 @@ class CommentsRetrieveUpdateDestroy(RetrieveUpdateDestroyAPIView, ListCreateAPIV
         data = {
             'body': body,
             'parent': parent,
-            'article': article.pk,
-            'author': request.user.id
+            'article': article.pk
         }
 
         serializer = self.serializer_class(
             data=data, context=context)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        serializer.save(author=request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def destroy(self, request, slug, id):


### PR DESCRIPTION
#### What does this PR do?
- Have a fix for comments
#### Description of Task to be completed?
- include a field for user profiles in response body for comment list

#### How should this be manually tested?
- Clone [this](https://github.com/andela/ah-shakas.git) repository and cd into the folder.
- Run the command ```git checkout bg-fix-comment-response-162158435```
- Create a ```.env``` file with the following values
```
DB_NAME=
DB_HOST=
DB_PASSWORD=
DB_USER=
EMAIL_HOST=smtp.sendgrid.net
EMAIL_HOST_USER=
EMAIL_HOST_PASSWORD=
EMAIL_PORT=
```
- Install the project dependencies by running ```pipenv install```
- Then to run the tests ren the command ```python manage.py test```
- Using [Postman](https://www.getpostman.com/) test every endpoint above after running the command ```python manage.py runserver```
- Create a user account by accessing ```POST api/users/``` and sending the following payload ```{ "user":{ "username":"username", "email":"username@gmail.com", "password": "password1234"}}```
- Confirm signup from the email sent to the address posted in the payload.
- Then login to get token to perform manual tests
_key_: Content-Type value: application/json
_key_: Authorization value: JWT Token generated either on signup or login
- Create an article by accessing ```POST api/articles/``` and pass in the following payload ```{"article":{"title":"title", "Title", "body": "My article"}}```
- Post comment by accessing ```POST api/articles/:slug/comments``` and pass the following payload
```
{
	"comment": {
		"body": "your comment"	
	}
	
}
```
- You will receive a response with authors profile
- get an article using the `api/article/:slug` endpoint and look out for the liked_status field
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
[#162158435](https://www.pivotaltracker.com/story/show/162158435)
#### Screenshots (if appropriate)
#### Questions:

[Finishes #162158435]