### PR TITLE
bug(fix-liking-of-comments): fix liking of comments in the backend

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -253,14 +253,12 @@ class CommentsSerializers(serializers.ModelSerializer):
 
     def get_like_status(self, obj):
             try:
-                    like_dislike_entry = CommentLike.objects.values_list(
-                            'comment_likes',flat=True).filter(
+                    like_dislike_entry = CommentLike.objects.get(
                             commentor=self.context["request"].user.id,specific_comment=obj.id
                             )
-                    if (like_dislike_entry[0]):
-                            return True
-            except Exception as e:
-                return None
+                    return True
+            except:
+                return False
 				
 
     history = serializers.SerializerMethodField()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -249,6 +249,22 @@ class CommentsSerializers(serializers.ModelSerializer):
         }
     )
 
+    like_status = serializers.SerializerMethodField()
+
+    def get_like_status(self, obj):
+            try:
+                    like_dislike_entry = CommentLike.objects.values_list(
+                            'comment_likes',flat=True).filter(
+                            commentor=self.context["request"].user.id,specific_comment=obj.id
+                            )
+                    if (like_dislike_entry[0]):
+                            return True
+                    else:
+                            return False
+            except Exception as e:
+                return None
+				
+
     history = serializers.SerializerMethodField()
 
     author = serializers.SerializerMethodField(read_only=True)
@@ -309,7 +325,8 @@ class CommentsSerializers(serializers.ModelSerializer):
            'author',
            'article',
            'parent',
-           'history'
+           'history',
+           'like_status',
        )
         
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -259,8 +259,6 @@ class CommentsSerializers(serializers.ModelSerializer):
                             )
                     if (like_dislike_entry[0]):
                             return True
-                    else:
-                            return False
             except Exception as e:
                 return None
 				

--- a/authors/apps/articles/tests/test_comment_like.py
+++ b/authors/apps/articles/tests/test_comment_like.py
@@ -138,3 +138,11 @@ class LikesDislikesTests(BaseTest):
         old_count = 1
         self.create_like()
         self.assertNotEqual(comment_like_count, old_count)
+
+    def test_like_status_on_dislike(self):
+        response = self.client.get(self.comment_url, format='json')
+        like_status = response.data['like_status']
+        self.create_like()
+        response = self.client.get(self.comment_url, format='json')
+        new_like_status = response.data['like_status']
+        self.assertNotEqual(like_status, new_like_status)

--- a/authors/apps/articles/tests/test_comments.py
+++ b/authors/apps/articles/tests/test_comments.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from authors.apps.articles.tests.base_tests import BaseTest, API_Reverse, APITestCase, APIClient
+import json
 
 class CommentsTests(BaseTest):
     """
@@ -192,3 +193,9 @@ class CommentsTests(BaseTest):
         url = API_Reverse('articles:comment-details', {slug: 'slug', 1: 'id'})
         response = self.client.put(url, data={'comment': {'body': 'New comment'}}, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def get_like_comment_url(self):
+        slug = self.create_article()
+        url = API_Reverse('articles:comments', {slug: 'slug'})
+        response = self.client.post(url, self.comment, format='json')
+        self.assertIn("like_status", json.dumps(response.data))

--- a/authors/apps/articles/tests/test_comments.py
+++ b/authors/apps/articles/tests/test_comments.py
@@ -1,6 +1,5 @@
 from rest_framework import status
 from authors.apps.articles.tests.base_tests import BaseTest, API_Reverse, APITestCase, APIClient
-import json
 
 class CommentsTests(BaseTest):
     """
@@ -193,11 +192,3 @@ class CommentsTests(BaseTest):
         url = API_Reverse('articles:comment-details', {slug: 'slug', 1: 'id'})
         response = self.client.put(url, data={'comment': {'body': 'New comment'}}, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    def get_like_status(self):
-        """This method tests whether the API returns mail url"""
-        self.create_user()
-        self.activate_user()
-        token = self.login_user()
-        response = self.client.post(self.url, self.comment, format="json", HTTP_AUTHORIZATION=token)
-        self.assertIn("like_status", json.dumps(response.data))

--- a/authors/apps/articles/tests/test_comments.py
+++ b/authors/apps/articles/tests/test_comments.py
@@ -1,5 +1,6 @@
 from rest_framework import status
 from authors.apps.articles.tests.base_tests import BaseTest, API_Reverse, APITestCase, APIClient
+import json
 
 class CommentsTests(BaseTest):
     """
@@ -192,3 +193,11 @@ class CommentsTests(BaseTest):
         url = API_Reverse('articles:comment-details', {slug: 'slug', 1: 'id'})
         response = self.client.put(url, data={'comment': {'body': 'New comment'}}, format='json')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def get_like_status(self):
+        """This method tests whether the API returns mail url"""
+        self.create_user()
+        self.activate_user()
+        token = self.login_user()
+        response = self.client.post(self.url, self.comment, format="json", HTTP_AUTHORIZATION=token)
+        self.assertIn("like_status", json.dumps(response.data))

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -393,7 +393,7 @@ class CommentsListCreateView(ListCreateAPIView):
         if isinstance(article, dict):
             return Response(article, status=status.HTTP_404_NOT_FOUND)
         comments = article.comments.filter(parent=None)
-        serializer = self.serializer_class(comments.all(), many=True)
+        serializer = self.serializer_class(comments.all(), context={'request': request}, many=True)
         data = {
             'count': comments.count(),
             'comments': serializer.data


### PR DESCRIPTION
#### What does this PR do?
* Users should be able to have a way of knowing if they have liked a specific comments before.
#### Description of Task to be completed?
* add a like_status field to the Comments serializer.
#### How should this be manually tested?
* Clone this repository from [here](https://github.com/andela/ah-shakas)
* cd into the repository and run ` bg-fix-liking-of-comments-162162620`
* Install requirements by running `pipenv install`
* activate virtual environment by running `pipenv shell`
* run migrations by running command `python manage.py migrate`
* Start the project by running `python manage.py runserver` 
* Using postman,create a user through the endpoint `/api/users/`
* payload for create user is :
```
              {
              "user":{
              "username":"lala",
              "email": "aleni@jake.jake",
              "password": "jakejake1"
                          }
                }    
```
* login at endpoint `/api/users/login/` using the same payload as above
* create an article at endpoint `/api/articles/` below is an example of a payoload.
```
{
  "article": {
    "title": "Hey Don",
    "description": "What's up?",
    "body": "He who knows not and knows not that he knows not is a fool"
                }
}
```
* provide authorisation before you create an article at the headers:
`_key_:Authorization, _value_:Token you obtained from login.`
* create comment at endpoint POST `api/articles/{slug}/comments/` and put the following payload
```
{
  "comment": {
    "body": "His name was my name too."
  }
}
```
* to like a comment, go to endpoint `POST /api/articles/{slug}/comments/{id}/like` and post with an example of the following example:
```
{
  "comment_likes":true
}
```
* to unlike, go to endpoint `DELETE /api/articles/{slug}/comments/{id}/like`
* to get your like status go to endpoint `GET /api/articles/{slug}/comments/{id}/`
#### Any background context you want to provide?
 * A user should be authenticated before you test.
#### What are the relevant pivotal tracker stories?
* None
#### Screenshots:
<img width="1049" alt="screenshot 2018-11-23 at 07 28 05" src="https://user-images.githubusercontent.com/23398223/48928549-41025100-eef1-11e8-9f7a-4f0073e25df2.png">


