### PR TITLE
#162238600 user can view subscription status

### DIFF
--- a/authors/apps/notifications/test_notifications.py
+++ b/authors/apps/notifications/test_notifications.py
@@ -1,6 +1,7 @@
 from authors.apps.articles.tests.base_tests import BaseTest
 from rest_framework import status
 from rest_framework.reverse import reverse
+import json
 from django.core import mail
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -25,6 +26,7 @@ class TestUserNotifications(BaseTest):
         self.unsubscribe = reverse('notifications:unsubscribe')
         self.all_notifications = reverse('notifications:notification')
         self.follow_url = reverse("profiles:follow", kwargs={"username": self.user['user']['username']})
+        self.is_subscribed = reverse('notifications:is_subscribed')
 
     def test_notifications_subscription(self):
         resp = self.client.get(self.subscribe)
@@ -74,5 +76,14 @@ class TestUserNotifications(BaseTest):
             if created:
                 instance = self.slug
                 return instance
+
+    def test_check_subscription_status(self):
+        # is_subscribed endpoint a user who has subscribed has a response of true
+        self.client.get(self.subscribe)
+        response = self.client.get(self.is_subscribed)
+        response_body = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response_body['is_subscribed'])
+        
 
 

--- a/authors/apps/notifications/urls.py
+++ b/authors/apps/notifications/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import NotificationAPIView, SubscribeAPIView, UnSubscribeAPIView
+from .views import NotificationAPIView, SubscribeAPIView, UnSubscribeAPIView, IsSubscribedAPIView
 
 app_name = 'notifications'
 
@@ -7,4 +7,5 @@ urlpatterns = [
     path('notifications/', NotificationAPIView.as_view(), name='notification'),
     path('notifications/subscribe/', SubscribeAPIView.as_view(), name='subscribe'),
     path('notifications/unsubscribe/', UnSubscribeAPIView.as_view(), name='unsubscribe'),
+    path('notifications/is-subscribed/', IsSubscribedAPIView.as_view(), name='is_subscribed'),
 ]

--- a/authors/apps/notifications/views.py
+++ b/authors/apps/notifications/views.py
@@ -41,7 +41,7 @@ class SubscribeAPIView(generics.ListAPIView):
         else:
             user.is_subcribed = True
             user.save()
-            return Response({"Message": "You have successfully subscribed to notifications"}, status=status.HTTP_200_OK)
+            return Response({"Message": "You have successfully subscribed to notifications", "is_subscribed": user.is_subcribed}, status=status.HTTP_200_OK)
 
 
 class UnSubscribeAPIView(generics.ListAPIView):
@@ -60,4 +60,17 @@ class UnSubscribeAPIView(generics.ListAPIView):
         else:
             user.is_subcribed = False
             user.save()
-            return Response({"Message": "You have successfully unsubscribed to notifications"})
+            return Response({"Message": "You have successfully unsubscribed to notifications", "is_subscribed": user.is_subcribed})
+
+class IsSubscribedAPIView(generics.ListAPIView):
+    """
+    A view for checking if user is subscribed
+    """
+
+    renderer_classes = (JSONRenderer, )
+    permission_classes = (IsAuthenticated,)
+    serializer_class = UserSerializer
+    def get(self, request):
+        email = request.user
+        user = User.objects.get(email=email)
+        return Response({"is_subscribed": user.is_subcribed})


### PR DESCRIPTION
#### What does this PR do?
- fixes subscribe to notifications bug
#### Description of Task to be completed?
- adds notification subscription status to response when user subscribes or unsubscribes
- creates an endpoint for checking user subscription status
#### How should this be manually tested?
- Clone the github repository `git clone https://github.com/andela/ah-shakas` 

- In the project's root directory Create a `.env` with the following values

```
DB_NAME=
DB_PASSWORD=
DB_HOST=
DB_USER=
EMAIL_HOST=
EMAIL_HOST_USER=
EMAIL_HOST_PASSWORD=
EMAIL_PORT=
EMAIL_SENDER=
DB_NAME=
DB_USER=
DB_PASSWORD=
DB_HOST=
PASSWORD_RESET=
VERIFY_URL=http://localhost:3000/verify/
```

- Checkout to this PR's branch `git checkout bg-fix-notification-subscription-162238600`

- Create a virtual environment using [pipenv](https://pipenv.readthedocs.io/en/latest/) `pipenv shell`

 - Install dependencies `pipenv install`

- Run the tests `python manage.py test`

- To test with Postman, first run `python manage.py runserver` and use the endpoints
```
GET: /api/notifications/subscribe/
```
```
GET: /api/notifications/unsubscribe/
```
```
GET: /api/notifications/is-subscribed/
```
- The response body should have a boolean of the current subscription status of the user
#### Any background context you want to provide?
 - to access the above endpoints, the user must be authenticated. Register and login to test the feature
#### What are the relevant pivotal tracker stories?
[#162238600](https://www.pivotaltracker.com/story/show/162238600)
#### Screenshots (if appropriate)
<img width="1086" alt="screen shot 2018-11-27 at 18 50 34" src="https://user-images.githubusercontent.com/39160236/49093631-89b16580-f275-11e8-837c-ce3a1b92a97e.png">
<img width="1080" alt="screen shot 2018-11-27 at 18 51 05" src="https://user-images.githubusercontent.com/39160236/49093666-9df56280-f275-11e8-98b3-860ba8be8f68.png">
<img width="1078" alt="screen shot 2018-11-27 at 18 51 25" src="https://user-images.githubusercontent.com/39160236/49093681-a8aff780-f275-11e8-8db0-04828222ea72.png">
